### PR TITLE
Add bump script

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test": "dts test",
     "lint": "dts lint",
     "//degit:contracts": "cd contracts && npx degit CosmWasm/cosmwasm/contracts/hackatom#0.16 hackatom",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "bump": "bun scripts/bump.ts"
   },
   "husky": {
     "hooks": {

--- a/scripts/bump.ts
+++ b/scripts/bump.ts
@@ -1,0 +1,51 @@
+import { join } from 'path';
+
+interface Pkg {
+  version: string;
+  [key: string]: unknown;
+}
+
+function run(cmd: string[]) {
+  const result = Bun.spawnSync(cmd, { stdout: 'inherit', stderr: 'inherit' });
+  if (result.exitCode !== 0) {
+    throw new Error(`Command failed: ${cmd.join(' ')}`);
+  }
+}
+
+const args = process.argv.slice(2);
+let mode: 'major' | 'minor' | 'patch' = 'patch';
+for (const arg of args) {
+  if (arg === '--major') mode = 'major';
+  if (arg === '--minor') mode = 'minor';
+  if (arg === '--patch') mode = 'patch';
+}
+
+const pkgPath = join(import.meta.dir, '..', 'package.json');
+const pkgContent = await Bun.file(pkgPath).text();
+const pkg: Pkg = JSON.parse(pkgContent);
+const parts = pkg.version.split('.').map(Number);
+let [major, minor, patch] = parts;
+
+switch (mode) {
+  case 'major':
+    major += 1;
+    minor = 0;
+    patch = 0;
+    break;
+  case 'minor':
+    minor += 1;
+    patch = 0;
+    break;
+  case 'patch':
+    patch += 1;
+    break;
+}
+
+const newVersion = `${major}.${minor}.${patch}`;
+pkg.version = newVersion;
+await Bun.write(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+
+run(['git', 'add', 'package.json']);
+run(['git', 'commit', '-m', `Bump version to v${newVersion}`]);
+run(['git', 'tag', `v${newVersion}`]);
+console.log(`Bumped to v${newVersion}`);


### PR DESCRIPTION
## Summary
- add script for bumping version and tagging release using Bun APIs

## Testing
- `bun run lint` *(fails: prettier issues in repo)*
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_e_684a23f24d148321927e86cb91e1bf78